### PR TITLE
Add PlantUML PNG generation and upload as artifacts

### DIFF
--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -32,4 +32,14 @@ jobs:
           message: "Render PlantUML files"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      # Create output directory for PNG files
+      - name: Create output directory
+        run: mkdir -p output
+
+      # Upload PNG artifacts
+      - name: Upload PNG artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: plantuml-pngs
+          path: output

--- a/.github/workflows/plantuml.yml
+++ b/.github/workflows/plantuml.yml
@@ -25,6 +25,13 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v3
 
+      # Set up Java
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
     # PlantUML Generator
       - uses: grassedge/generate-plantuml-action@v1.5
         with:


### PR DESCRIPTION
Add steps to create an output directory and upload PNG artifacts in the GitHub Actions workflow.

* Create an output directory for PNG files.
* Upload PNG artifacts using `actions/upload-artifact@v3`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/keugenek/plantuml-ent-kit/pull/3?shareId=669e04dd-b49f-4c17-88d9-2d5676bccfb3).